### PR TITLE
Remove quantlib runtime dependency on Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win and vc<14]
 
 requirements:
@@ -31,11 +31,14 @@ requirements:
 
   run:
     - python
-    - quantlib
+    - quantlib  # [not win]
+    - boost-cpp  # [win]
 
 test:
-  imports:
-    - QuantLib
+  source_files:
+    - Python/test/*
+  commands:
+    - python Python/test/QuantLibTestSuite.py
 
 about:
   home: https://github.com/lballabio/QuantLib


### PR DESCRIPTION
Since quantlib is built as a static library on Windows there is no need for a runtime dependency on the quantlib library package.

Run python tests as part of package validation to confirm this.

This should only be merged and tests rerun after conda-forge/quantlib-feedstock#13 as the run_exports directive in the current quantlib package results in a runtime dependency on quantlib on Windows anyway.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
