### PR TITLE
fix: removed tests from the build scripts

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,5 @@
 cd Python
 python setup.py wrap
 python setup.py build
-python setup.py test
 python setup.py install
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,8 +5,3 @@
 make -C Python
 make -C Python wheel
 pip install Python/dist/*.whl
-
-# testing
-pushd Python
-pytest
-popd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,3 +57,4 @@ about:
 extra:
   recipe-maintainers:
     - timkpaine
+    - ruben-arts

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - no-isolation.diff
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and vc<14]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)


Non-applicable check boxes as I only removed the tests from the build scripts. 

This should unblock https://github.com/conda-forge/quantlib-python-feedstock/pull/45

Also added myself as maintainer to share the load ✋ 
